### PR TITLE
Use new DIM comment format

### DIFF
--- a/2. Searches/New Item Checking.txt
+++ b/2. Searches/New Item Checking.txt
@@ -1,1 +1,1 @@
-("New Item Checking" or (-(-is:armor -is:weapon) -is:classitem -is:maxpower is:new))
+/* New Item Checking */ (-(-is:armor -is:weapon) -is:classitem -is:maxpower is:new)

--- a/2. Searches/Recommended Items Search
+++ b/2. Searches/Recommended Items Search
@@ -1,16 +1,16 @@
-"Recommended Items Search | Try me in the Vendor tab!" or 
+/* Recommended Items Search | Try me in the Vendor tab! */
 (is:weapon -is:sunset is:wishlist) or (
 is:armor -is:classitem (
-	
-	((basestat:recovery&secondhighest:>=19 or 
+
+	((basestat:recovery&secondhighest:>=19 or
 	basestat:highest&recovery:>=19)
 	basestat:secondhighest:>10 basestat:fourthhighest:<10)
 	or
 
 	((basestat:recovery&secondhighest&thirdhighest:>=16.66 or
 	basestat:highest&recovery&thirdhighest:>=16.66 or
-	basestat:highest&secondhighest&recovery:>=16.66) 
-	basestat:thirdhighest:>10 basestat:thirdhighest:<20) 
+	basestat:highest&secondhighest&recovery:>=16.66)
+	basestat:thirdhighest:>10 basestat:thirdhighest:<20)
 	or
 
 	((basestat:recovery&secondhighest&thirdhighest&fourthhighest:>=14.25 or

--- a/2. Searches/Vault Analyzer End-Game
+++ b/2. Searches/Vault Analyzer End-Game
@@ -1,6 +1,5 @@
-("TMMania's Vault Analyzer End-Game Edition | Highlights Trash | Keeps Top 2.5% Armor |
-Update Version: #0029"
-or
+/* TMMania's Vault Analyzer End-Game Edition | Highlights Trash | Keeps Top 2.5% Armor |
+Update Version: #0029 */
 (
 (
 	(
@@ -30,10 +29,9 @@ or
 or
 	(is:armor is:sunset)
 or
-	(is:armor is:blue -(name:"war mantis" is:gauntlets))	
+	(is:armor is:blue -(name:"war mantis" is:gauntlets))
 or
 	((is:armor or is:weapon) and (is:common or is:uncommon))
 )
 -(is:tagged -tag:junk) -is:maxpower -power:pinnaclecap -is:inloadout -is:masterwork -(is:armor -is:armor2.0) -(is:armor source:events)
 )  or (tag:junk -is:maxpowerloadout)
-)

--- a/2. Searches/Vault Analyzer Mid-Game
+++ b/2. Searches/Vault Analyzer Mid-Game
@@ -1,6 +1,5 @@
-("TMMania's Vault Analyzer Mid-Game Edition | Highlights Trash | Keeps Top 7.5% Armor |
-Update Version: #0029"
-or
+/* TMMania's Vault Analyzer Mid-Game Edition | Highlights Trash | Keeps Top 7.5% Armor |
+Update Version: #0029 */
 (
 (
 	(
@@ -30,10 +29,9 @@ or
 or
 	(is:armor is:sunset)
 or
-	(is:armor is:blue -(name:"war mantis" is:gauntlets))	
+	(is:armor is:blue -(name:"war mantis" is:gauntlets))
 or
 	((is:armor or is:weapon) and (is:common or is:uncommon))
 )
 -(is:tagged -tag:junk) -is:maxpower -power:pinnaclecap -is:inloadout -is:masterwork -(is:armor -is:armor2.0) -(is:armor source:events)
 )  or (tag:junk -is:maxpowerloadout)
-)

--- a/2. Searches/Vault Analyzer.txt
+++ b/2. Searches/Vault Analyzer.txt
@@ -1,6 +1,5 @@
-("TMMania's Vault Analyzer | Highlights Trash |
-Update Version: #0032"
-or
+/* TMMania's Vault Analyzer | Highlights Trash |
+Update Version: #0032 */
 (
 (
 	(
@@ -21,7 +20,7 @@ or
 	-(basestat:highest&secondhighest&thirdhighest:>=15 -basestat:thirdhighest:<11)
 
 	-(basestat:highest&secondhighest&thirdhighest&fourthhighest:>=13.25 -basestat:fourthhighest:<10)
-	
+
 	-(basestat:highest&secondhighest&thirdhighest&fourthhighest&fifthhighest:>=11.8 -basestat:fifthhighest:<6)
 
 	-(basestat:mobility&resilience&recovery&discipline&intellect&strength:>=9 basestat:sixthhighest:>=7 basestat:highest:<16)
@@ -32,10 +31,9 @@ or
 or
 	(is:armor is:sunset)
 or
-	(is:armor is:blue -(name:"war mantis" is:gauntlets))	
+	(is:armor is:blue -(name:"war mantis" is:gauntlets))
 or
 	((is:armor or is:weapon) and (is:common or is:uncommon))
 )
 -(is:tagged -tag:junk) -is:maxpower -power:pinnaclecap -is:inloadout -is:masterwork -(is:armor -is:armor2.0) -(is:armor source:events)
 )  or (tag:junk -is:maxpowerloadout)
-)

--- a/3. Stat Summation Searches/Dual Stat Summations.txt
+++ b/3. Stat Summation Searches/Dual Stat Summations.txt
@@ -1,2 +1,2 @@
-("Dual Stat Summations" or 
-(basestat:highest+secondhighest:>=40))
+/* Dual Stat Summations */
+(basestat:highest+secondhighest:>=40)

--- a/3. Stat Summation Searches/Triple Stat Summations.txt
+++ b/3. Stat Summation Searches/Triple Stat Summations.txt
@@ -1,2 +1,2 @@
-("Triple Stat Summations" or
-(basestat:highest+secondhighest+thirdhighest:>=45))
+/* Triple Stat Summations */
+(basestat:highest+secondhighest+thirdhighest:>=45)

--- a/4. Stat Average Searches/Dual Stat Averages
+++ b/4. Stat Average Searches/Dual Stat Averages
@@ -1,2 +1,2 @@
-("Dual Stat Averages" or
-(basestat:highest&secondhighest:>=17.5 -basestat:secondhighest:<15))
+/* Dual Stat Averages */
+(basestat:highest&secondhighest:>=17.5 -basestat:secondhighest:<15)

--- a/4. Stat Average Searches/Full House Averages.txt
+++ b/4. Stat Average Searches/Full House Averages.txt
@@ -1,2 +1,2 @@
-("Full House Stat Split" or 
-(basestat:mobility&resilience&recovery&discipline&intellect&strength:>=9 basestat:sixthhighest:>5 basestat:highest:<15))
+/* Full House Stat Split */
+(basestat:mobility&resilience&recovery&discipline&intellect&strength:>=9 basestat:sixthhighest:>5 basestat:highest:<15)

--- a/4. Stat Average Searches/Quad Stat Averages
+++ b/4. Stat Average Searches/Quad Stat Averages
@@ -1,2 +1,2 @@
-("Quad Stat Averages" or
-(basestat:highest&secondhighest&thirdhighest&fourthhighest:>=13.25 -basestat:fourthhighest:<10))
+/* Quad Stat Averages */
+(basestat:highest&secondhighest&thirdhighest&fourthhighest:>=13.25 -basestat:fourthhighest:<10)

--- a/4. Stat Average Searches/Triple Stat Averages.txt
+++ b/4. Stat Average Searches/Triple Stat Averages.txt
@@ -1,2 +1,2 @@
-("Triple Stat Averages" or
-(basestat:highest&secondhighest&thirdhighest:>=15 -basestat:thirdhighest:<11))
+/* Triple Stat Averages */
+(basestat:highest&secondhighest&thirdhighest:>=15 -basestat:thirdhighest:<11)


### PR DESCRIPTION
Use the comment format added in DestinyItemManager/DIM#8205 instead of the `"string" or` format.

I didn't bump the revision numbers in the searches that have them, since the meat of the search remains the same.