### PR TITLE
Fix thirdhighest threshold in 3-stats filter

### DIFF
--- a/2. Searches/Vault Analyzer.txt
+++ b/2. Searches/Vault Analyzer.txt
@@ -16,7 +16,7 @@ or
 	
 	-(basestat:highest:>=23 basestat:secondhighest:>=10 (basestat:recovery:>=23 or (is:hunter (basestat:mobility:>=23 or basestat:recovery:>=23))))
 	-(basestat:highest&secondhighest:>=18 basestat:secondhighest:>=13 (basestat:recovery:>=13 basestat:mobility:<13 or (is:hunter (basestat:mobility:>=13 or basestat:recovery:>=13))))
-	-(basestat:highest&secondhighest&thirdhighest:>=15 basestat:secondhighest:>=11 (basestat:recovery:>=11 basestat:mobility:<11 or (is:hunter (basestat:mobility:>=11 or basestat:recovery:>=11))))
+	-(basestat:highest&secondhighest&thirdhighest:>=15 basestat:thirdhighest:>=11 (basestat:recovery:>=11 basestat:mobility:<11 or (is:hunter (basestat:mobility:>=11 or basestat:recovery:>=11))))
 	-(basestat:highest&secondhighest&thirdhighest&fourthhighest:>=13.25 basestat:fourthhighest:>=10 (basestat:recovery:>=10 basestat:mobility:<10 or (is:hunter (basestat:mobility:>=10 or basestat:recovery:>=10))))
 	-(basestat:highest&secondhighest&thirdhighest&fourthhighest&fifthhighest:>=11.6 basestat:fifthhighest:>=6 (basestat:recovery:>=6 basestat:mobility:<6 or (is:hunter (basestat:mobility:>=6 or basestat:recovery:>=6))))
 	-(basestat:highest&secondhighest&thirdhighest&fourthhighest&fifthhighest&sixthhighest:>=9.833 basestat:sixthhighest:>=6)


### PR DESCRIPTION
I think there's an error on the 3-stats filter, it should be `basestat:thirdhighest:>=11` instead of `basestat:secondhighest>=11`, am I right?
If yes, we can add the mid- and end-game files in the PR.
If I'm wrong... ignore me.